### PR TITLE
Fix framework versions

### DIFF
--- a/src/Jsonyte.Tests/Jsonyte.Tests.csproj
+++ b/src/Jsonyte.Tests/Jsonyte.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net472;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Jsonyte/Converters/JsonApiStateConverter.cs
+++ b/src/Jsonyte/Converters/JsonApiStateConverter.cs
@@ -15,7 +15,7 @@ namespace Jsonyte.Converters
 
         public ConcurrentDictionary<Type, AnonymousRelationshipConverter> AnonymousConverters { get; } = new();
 
-#if NETCOREAPP || NETFRAMEWORK
+#if NETCOREAPP || NETFRAMEWORK || NETSTANDARD2_1_OR_GREATER
         public MemberAccessor MemberAccessor { get; } = new EmitMemberAccessor();
 #else
         public MemberAccessor MemberAccessor { get; } = new ReflectionMemberAccessor();

--- a/src/Jsonyte/Jsonyte.csproj
+++ b/src/Jsonyte/Jsonyte.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>0.1.0</Version>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net472;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Jsonyte/Serialization/Reflection/EmitMemberAccessor.cs
+++ b/src/Jsonyte/Serialization/Reflection/EmitMemberAccessor.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP || NETFRAMEWORK
+﻿#if NETCOREAPP || NETFRAMEWORK || NETSTANDARD2_1_OR_GREATER
 using System;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/src/Jsonyte/Serialization/Reflection/ReflectionMemberAccessor.cs
+++ b/src/Jsonyte/Serialization/Reflection/ReflectionMemberAccessor.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP && !NETFRAMEWORK
+﻿#if !NETCOREAPP && !NETFRAMEWORK && !NETSTANDARD2_1_OR_GREATER
 using System;
 using System.Reflection;
 


### PR DESCRIPTION
Net framework 472 can benefit from the faster Emit code, but it was pulling netstandard2.0 version which only has the slower reflection code.