### PR TITLE
Added an attribute to indicate how a relationship is serialized

### DIFF
--- a/src/Jsonyte.Tests/Jsonyte.Tests.csproj
+++ b/src/Jsonyte.Tests/Jsonyte.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="JsonApiSerializer" Version="1.7.4" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.1" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.7.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.5.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/src/Jsonyte.Tests/Models/ModelReferencingItselfWithIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelReferencingItselfWithIdAndTypeRelationship.cs
@@ -1,0 +1,21 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-referencing-itself-with-id-and-type-relationship")]
+    internal class ModelReferencingItselfWithIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        public string Value { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public ModelReferencingItselfWithIdAndTypeRelationship Itself { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithAnonymousCollectionIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithAnonymousCollectionIdAndTypeRelationship.cs
@@ -1,0 +1,15 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System.Collections.Generic;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-anonymous-collection-id-and-type-relationship")]
+    internal class ModelWithAnonymousCollectionIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public IEnumerable<ModelWithAttribute> AnonymousCollection { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithArrayIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithArrayIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-array-id-and-type-relationship")]
+    internal class ModelWithArrayIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public ModelWithAttribute[] Array { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithExplicitAnonymousCollectionIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithExplicitAnonymousCollectionIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-explicit-anonymous-collection-id-and-type-relationship")]
+    internal class ModelWithExplicitAnonymousCollectionIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public JsonApiRelationship<IEnumerable<ModelWithAttribute>> ExplicitAnonymousCollection { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithExplicitArrayIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithExplicitArrayIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-explicit-array-id-and-type-relationship")]
+    internal class ModelWithExplicitArrayIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public JsonApiRelationship<ModelWithAttribute[]> ExplicitArray { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithExplicitIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithExplicitIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-explicit-id-and-type-relationship")]
+    internal class ModelWithExplicitIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public JsonApiRelationship<ModelWithAttribute> ExplicitModel { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithExplicitObjectIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithExplicitObjectIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-explicit-object-id-and-type-relationship")]
+    internal class ModelWithExplicitObjectIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public JsonApiRelationship<object> ExplicitObject { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithExplicitPotentialCollectionIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithExplicitPotentialCollectionIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-explicit-potential-collection-id-and-type-relationship")]
+    internal class ModelWithExplicitPotentialCollectionIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public JsonApiRelationship<IEnumerable<object>> ExplicitPotentialCollection { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-id-and-type-relationship")]
+    internal class ModelWithIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public ModelWithAttribute Model { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithNestedIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithNestedIdAndTypeRelationship.cs
@@ -1,0 +1,18 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-nested-id-and-type-relationship")]
+    internal class ModelWithNestedIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        public ModelWithIdAndTypeRelationship Model { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithObjectIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithObjectIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-object-id-and-type-relationship")]
+    internal class ModelWithObjectIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public object Object {get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithPotentialCollectionIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithPotentialCollectionIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-potential-collection-id-and-type-relationship")]
+    internal class ModelWithPotentialCollectionIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public IEnumerable<object> PotentialCollection { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Models/ModelWithUselessIdAndTypeRelationship.cs
+++ b/src/Jsonyte.Tests/Models/ModelWithUselessIdAndTypeRelationship.cs
@@ -1,0 +1,19 @@
+﻿using Jsonyte.Serialization;
+using Jsonyte.Serialization.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jsonyte.Tests.Models
+{
+    [JsonApiResource("model-with-useless-id-and-type-relationship")]
+    internal class ModelWithUselessIdAndTypeRelationship
+    {
+        public string Id { get; set; }
+
+        [SerializeAs(type: RelationshipSerializationType.IdAndType)]
+        public string Value { get; set; }
+    }
+}

--- a/src/Jsonyte.Tests/Serialization/SerializeDocumentTests.cs
+++ b/src/Jsonyte.Tests/Serialization/SerializeDocumentTests.cs
@@ -344,6 +344,99 @@ namespace Jsonyte.Tests.Serialization
         }
 
         [Fact]
+        public void CanSerializeIdandTypeOnlyRelationship() {
+            var model = new ModelWithIdAndTypeRelationship
+            {
+                Id = "1",
+                Model = new ModelWithAttribute
+                {
+                    Id = "2",
+                    Value = "2",
+                    IntValue = 2
+                }
+            };
+
+            var document = JsonApiDocument.Create(model);
+
+            var json = document.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-id-and-type-relationship',
+                    'relationships': {
+                      'model': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-attribute'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+         [Fact]
+        public void CanSerializeIdandTypeOnlyRelationshipCollection()
+        {
+            var model1 = new ModelWithIdAndTypeRelationship
+            {
+                Id = "1",
+                Model = new ModelWithAttribute
+                {
+                    Id = "2",
+                    Value = "2",
+                    IntValue = 2
+                }
+            };
+            var model2 = new ModelWithIdAndTypeRelationship
+            {
+                Id = "3",
+                Model = new ModelWithAttribute
+                {
+                    Id = "4",
+                    Value = "4",
+                    IntValue = 4
+                }
+            };
+
+            var document = JsonApiDocument.Create(new[] { model1, model2 });
+
+            var json = document.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': [
+                    {
+                      'id': '1',
+                      'type': 'model-with-id-and-type-relationship',
+                      'relationships': {
+                        'model': {
+                          'data': {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'id': '3',
+                      'type': 'model-with-id-and-type-relationship',
+                      'relationships': {
+                        'model': {
+                          'data': {
+                            'id': '4',
+                            'type': 'model-with-attribute'
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
         public void CanSerializeIncludedAndRelationshipsWithDocument()
         {
             var document = new JsonApiDocument

--- a/src/Jsonyte.Tests/Serialization/SerializeIdAndTypeRelationships.cs
+++ b/src/Jsonyte.Tests/Serialization/SerializeIdAndTypeRelationships.cs
@@ -1,0 +1,617 @@
+﻿using Jsonyte.Tests.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jsonyte.Tests.Serialization
+{
+    public class SerializeIdAndTypeRelationships
+    {
+        [Fact]
+        public void CanSerializeModelWithAnonymousCollectionIdAndTypeRelationship() {
+            var model = new ModelWithAnonymousCollectionIdAndTypeRelationship
+            {
+                Id = "1",
+                AnonymousCollection = new List<ModelWithAttribute>
+                {
+                    new ModelWithAttribute
+                    {
+                        Id = "2",
+                        Value = "2",
+                        IntValue = 2
+                    },
+                    new ModelWithAttribute
+                    {
+                        Id = "3",
+                        Value = "3",
+                        IntValue = 3
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-anonymous-collection-id-and-type-relationship',
+                    'relationships': {
+                      'anonymousCollection': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithExplicitAnonymousCollectionIdAndTypeRelationship() {
+            var model = new ModelWithExplicitAnonymousCollectionIdAndTypeRelationship
+            {
+                Id = "1",
+                ExplicitAnonymousCollection = new JsonApiRelationship<IEnumerable<ModelWithAttribute>>
+                {
+                    Data = new List<ModelWithAttribute>
+                    {
+                        new ModelWithAttribute
+                        {
+                            Id = "2",
+                            Value = "2",
+                            IntValue = 2
+                        },
+                        new ModelWithAttribute
+                        {
+                            Id = "3",
+                            Value = "3",
+                            IntValue = 3
+                        }
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-explicit-anonymous-collection-id-and-type-relationship',
+                    'relationships': {
+                      'explicitAnonymousCollection': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithPotentialCollectionIdAndTypeRelationship(){
+            var model = new ModelWithPotentialCollectionIdAndTypeRelationship
+            {
+                Id = "1",
+                PotentialCollection = new List<object>
+                {
+                    new
+                    {
+                        id = "2",
+                        type = "model-with-attribute",
+                        value = "2",
+                        intValue = 2
+                    },
+                    new
+                    {
+                        id = "3",
+                        type = "model-with-attribute",
+                        value = "3",
+                        intValue = 3
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-potential-collection-id-and-type-relationship',
+                    'relationships': {
+                      'potentialCollection': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithExplicitPotentialCollectionIdAndTypeRelationship(){
+            var model = new ModelWithExplicitPotentialCollectionIdAndTypeRelationship
+            {
+                Id = "1",
+                ExplicitPotentialCollection = new JsonApiRelationship<IEnumerable<object>>
+                {
+                    Data = new List<object>
+                    {
+                        new
+                        {
+                            id = "2",
+                            type = "model-with-attribute",
+                            value = "2",
+                            intValue = 2
+                        },
+                        new
+                        {
+                            id = "3",
+                            type = "model-with-attribute",
+                            value = "3",
+                            intValue = 3
+                        }
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-explicit-potential-collection-id-and-type-relationship',
+                    'relationships': {
+                      'explicitPotentialCollection': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithObjectIdAndTypeRelationship() {
+             var model = new ModelWithObjectIdAndTypeRelationship()
+             {
+                 Id = "1",
+                 Object = new
+                 {
+                     id = "2",
+                     type = "model-with-attribute",
+                     value = "2",
+                     intValue = 2,
+                     Object = new ModelWithAttribute
+                     {
+                         Id = "2",
+                         Value = "2",
+                         IntValue = 2
+                     }
+                 }
+             };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-object-id-and-type-relationship',
+                    'relationships': {
+                      'object': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-attribute'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelReferencingItselfWithIdAndTypeRelationship()
+        {
+            var model = new ModelReferencingItselfWithIdAndTypeRelationship
+            {
+                Id = "1",
+                Value = "2",
+            };
+
+            model.Itself =  model;
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-referencing-itself-with-id-and-type-relationship',
+                    'attributes': {
+                      'value': '2'
+                    },
+                    'relationships': {
+                      'itself': {
+                        'data': {
+                          'id': '1',
+                          'type': 'model-referencing-itself-with-id-and-type-relationship'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithArrayIdAndTypeRelationship()
+        {
+            var model = new ModelWithArrayIdAndTypeRelationship
+            {
+                Id = "1",
+                Array = new[]
+                {
+                    new ModelWithAttribute
+                    {
+                        Id = "2",
+                        Value = "2",
+                        IntValue = 2
+                    },
+                    new ModelWithAttribute
+                    {
+                        Id = "3",
+                        Value = "3",
+                        IntValue = 3
+                    }
+                }
+            };
+            var json = model.Serialize();
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-array-id-and-type-relationship',
+                    'relationships': {
+                      'array': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithExplicitArrayIdAndTypeRelationship()
+        {
+            var model = new ModelWithExplicitArrayIdAndTypeRelationship
+            {
+                Id = "1",
+                ExplicitArray = new JsonApiRelationship<ModelWithAttribute[]>
+                {
+                    Data = new[]
+                    {
+                        new ModelWithAttribute
+                        {
+                            Id = "2",
+                            Value = "2",
+                            IntValue = 2
+                        },
+                        new ModelWithAttribute
+                        {
+                            Id = "3",
+                            Value = "3",
+                            IntValue = 3
+                        }
+                    }
+                }
+            };
+            var json = model.Serialize();
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-explicit-array-id-and-type-relationship',
+                    'relationships': {
+                      'explicitArray': {
+                        'data': [
+                          {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          },
+                          {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithExplicitIdAndTypeRelationship()
+        {
+            var model = new ModelWithExplicitIdAndTypeRelationship
+            {
+                Id = "1",
+                ExplicitModel = new JsonApiRelationship<ModelWithAttribute>
+                {
+                    Data = new ModelWithAttribute
+                    {
+                        Id = "2",
+                        Value = "2",
+                        IntValue = 2
+                    }
+                }
+            };
+            var json = model.Serialize();
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-explicit-id-and-type-relationship',
+                    'relationships': {
+                      'explicitModel': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-attribute'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithExplicitObjectIdAndTypeRelationship()
+        {
+            var model = new ModelWithExplicitObjectIdAndTypeRelationship
+            {
+                Id = "1",
+                ExplicitObject = new JsonApiRelationship<object>
+                {
+                    Data = new
+                    {
+                        id = "2",
+                        type = "model-with-attribute",
+                        value = "2",
+                        intValue = 2,
+                        Object = new ModelWithAttribute
+                        {
+                            Id = "3",
+                            Value = "3",
+                            IntValue = 3
+                        }
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-explicit-object-id-and-type-relationship',
+                    'relationships': {
+                      'explicitObject': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-attribute'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithIdAndTypeRelationship()
+        {
+            var model = new ModelWithIdAndTypeRelationship
+            {
+                Id = "1",
+                Model = new ModelWithAttribute
+                {
+                    Id = "2",
+                    Value = "2",
+                    IntValue = 2
+                }
+            };
+            var json = model.Serialize();
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-id-and-type-relationship',
+                    'relationships': {
+                      'model': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-attribute'
+                        }
+                      }
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void ModelWithNestedIdAndTypeRelationship()
+        {
+            var model = new ModelWithNestedIdAndTypeRelationship
+            {
+                Id = "1",
+                Model = new ModelWithIdAndTypeRelationship
+                {
+                    Id = "2",
+                    Model = new ModelWithAttribute
+                    {
+                        Id = "3",
+                        Value = "3",
+                        IntValue = 3
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-nested-id-and-type-relationship',
+                    'relationships': {
+                      'model': {
+                        'data': {
+                          'id': '2',
+                          'type': 'model-with-id-and-type-relationship'
+                        }
+                      }
+                    }
+                  },
+                  'included': [
+                    {
+                      'id': '2',
+                      'type': 'model-with-id-and-type-relationship',
+                      'relationships': {
+                        'model': {
+                          'data': {
+                            'id': '3',
+                            'type': 'model-with-attribute'
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithIdAndTypeRelationshipCollection()
+        {
+            var model = new List<ModelWithIdAndTypeRelationship>
+            {
+                new ModelWithIdAndTypeRelationship {
+                    Id = "1",
+                    Model = new ModelWithAttribute
+                    {
+                        Id = "2",
+                        Value = "2",
+                        IntValue = 2
+                    }
+                },
+                new ModelWithIdAndTypeRelationship {
+                    Id = "3",
+                    Model = new ModelWithAttribute
+                    {
+                        Id = "4",
+                        Value = "4",
+                        IntValue = 4
+                    }
+                }
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': [
+                    {
+                      'id': '1',
+                      'type': 'model-with-id-and-type-relationship',
+                      'relationships': {
+                        'model': {
+                          'data': {
+                            'id': '2',
+                            'type': 'model-with-attribute'
+                          }
+                        }
+                      }
+                    },
+                    {
+                      'id': '3',
+                      'type': 'model-with-id-and-type-relationship',
+                      'relationships': {
+                        'model': {
+                          'data': {
+                            'id': '4',
+                            'type': 'model-with-attribute'
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+
+        [Fact]
+        public void CanSerializeModelWithUselessIdAndTypeRelationship()
+        {
+            var model = new ModelWithUselessIdAndTypeRelationship
+            {
+                Id = "1",
+                Value = "2"
+            };
+
+            var json = model.Serialize();
+
+            Assert.Equal(@"
+                {
+                  'data': {
+                    'id': '1',
+                    'type': 'model-with-useless-id-and-type-relationship',
+                    'attributes': {
+                      'value': '2'
+                    }
+                  }
+                }".Format(), json, JsonStringEqualityComparer.Default);
+        }
+    }
+}

--- a/src/Jsonyte/Converters/AnonymousRelationshipConverter.cs
+++ b/src/Jsonyte/Converters/AnonymousRelationshipConverter.cs
@@ -6,9 +6,9 @@ namespace Jsonyte.Converters
 {
     internal abstract class AnonymousRelationshipConverter
     {
-        public abstract void Write(Utf8JsonWriter writer, ref TrackedResources tracked, object value, JsonSerializerOptions options);
+        public abstract void Write(Utf8JsonWriter writer, ref TrackedResources tracked, object value, RelationshipSerializationType relationshipSerializationType, JsonSerializerOptions options);
 
-        public abstract void WriteWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object value, JsonSerializerOptions options);
+        public abstract void WriteWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object value, RelationshipSerializationType relationshipSerializationType, JsonSerializerOptions options);
     }
 
     internal class AnonymousRelationshipConverter<T> : AnonymousRelationshipConverter
@@ -20,14 +20,14 @@ namespace Jsonyte.Converters
 
         public JsonApiRelationshipDetailsConverter<T> Converter { get; }
 
-        public override void Write(Utf8JsonWriter writer, ref TrackedResources tracked, object value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, ref TrackedResources tracked, object value, RelationshipSerializationType relationshipSerializationType, JsonSerializerOptions options)
         {
-            Converter.Write(writer, ref tracked, new RelationshipResource<T>((T) value), options);
+            Converter.Write(writer, ref tracked, new RelationshipResource<T>((T) value, relationshipSerializationType), options);
         }
 
-        public override void WriteWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object value, JsonSerializerOptions options)
+        public override void WriteWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object value, RelationshipSerializationType relationshipSerializationType, JsonSerializerOptions options)
         {
-            Converter.WriteWrapped(writer, ref tracked, new RelationshipResource<T>((T) value), options);
+            Converter.WriteWrapped(writer, ref tracked, new RelationshipResource<T>((T) value, relationshipSerializationType), options);
         }
     }
 }

--- a/src/Jsonyte/Converters/Collections/JsonApiPotentialRelationshipCollectionConverter.cs
+++ b/src/Jsonyte/Converters/Collections/JsonApiPotentialRelationshipCollectionConverter.cs
@@ -145,11 +145,11 @@ namespace Jsonyte.Converters.Collections
 
                 writer.WriteEndObject();
 
-                tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, converter, value);
+                tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, converter, value, relationshipSerializationType: container.RelationshipSerializationType);
             }
             else
             {
-                tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, converter, value, container.Relationship);
+                tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, converter, value, container.Relationship, container.RelationshipSerializationType);
             }
         }
 

--- a/src/Jsonyte/Converters/Collections/JsonApiRelationshipCollectionConverter.cs
+++ b/src/Jsonyte/Converters/Collections/JsonApiRelationshipCollectionConverter.cs
@@ -105,7 +105,7 @@ namespace Jsonyte.Converters.Collections
 
                 foreach (var element in collection)
                 {
-                    var resource = new RelationshipResource<TElement>(element);
+                    var resource = new RelationshipResource<TElement>(element, value.RelationshipSerializationType);
 
                     converter.WriteWrapped(writer, ref tracked, resource, options);
                 }

--- a/src/Jsonyte/Converters/Collections/JsonApiResourceObjectCollectionConverter.cs
+++ b/src/Jsonyte/Converters/Collections/JsonApiResourceObjectCollectionConverter.cs
@@ -114,7 +114,7 @@ namespace Jsonyte.Converters.Collections
                 {
                     var included = tracked.Get(index);
 
-                    if (!tracked.IsEmitted(included))
+                    if (included.ShouldSerialize() && !tracked.IsEmitted(included))
                     {
                         if (!nameWritten)
                         {

--- a/src/Jsonyte/Converters/Objects/JsonApiDocumentDataConverter.cs
+++ b/src/Jsonyte/Converters/Objects/JsonApiDocumentDataConverter.cs
@@ -226,7 +226,7 @@ namespace Jsonyte.Converters.Objects
             {
                 var included = tracked.Get(index);
 
-                if (!tracked.IsEmitted(included))
+                if (included.ShouldSerialize() && !tracked.IsEmitted(included))
                 {
                     if (!nameWritten)
                     {
@@ -257,7 +257,7 @@ namespace Jsonyte.Converters.Objects
             {
                 var included = tracked.Get(index);
 
-                if (!tracked.IsEmitted(included))
+                if (included.ShouldSerialize() && !tracked.IsEmitted(included))
                 {
                     if (!nameWritten)
                     {

--- a/src/Jsonyte/Converters/Objects/JsonApiResourceObjectConverter.cs
+++ b/src/Jsonyte/Converters/Objects/JsonApiResourceObjectConverter.cs
@@ -210,7 +210,7 @@ namespace Jsonyte.Converters.Objects
                 {
                     var included = tracked.Get(index);
 
-                    if (!tracked.IsEmitted(included))
+                    if (included.ShouldSerialize() && !tracked.IsEmitted(included))
                     {
                         if (!nameWritten)
                         {

--- a/src/Jsonyte/Converters/Objects/JsonApiResourceObjectExplicitRelationshipConverter.cs
+++ b/src/Jsonyte/Converters/Objects/JsonApiResourceObjectExplicitRelationshipConverter.cs
@@ -69,7 +69,8 @@ namespace Jsonyte.Converters.Objects
 
         public override void Write(Utf8JsonWriter writer, RelationshipResource<T> value, JsonSerializerOptions options)
         {
-            throw new NotSupportedException();
+            var tracked = new TrackedResources();
+            this.Write(writer, ref tracked, value, options);
         }
 
         public override void Write(Utf8JsonWriter writer, ref TrackedResources tracked, RelationshipResource<T> value, JsonSerializerOptions options)
@@ -106,7 +107,7 @@ namespace Jsonyte.Converters.Objects
             if (data != null)
             {
                 writer.WritePropertyName(JsonApiMembers.DataEncoded);
-                info.DataMember.WriteRelationshipWrapped(writer, ref tracked, value.Resource);
+                info.DataMember.WriteRelationshipWrapped(writer, ref tracked, value.Resource, value.RelationshipSerializationType);
             }
 
             info.LinksMember.Write(writer, ref tracked, value.Resource);

--- a/src/Jsonyte/Converters/Objects/JsonApiResourceObjectRelationshipConverter.cs
+++ b/src/Jsonyte/Converters/Objects/JsonApiResourceObjectRelationshipConverter.cs
@@ -128,7 +128,7 @@ namespace Jsonyte.Converters.Objects
 
             writer.WriteEndObject();
 
-            tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, GetConverter(options), value.Resource);
+            tracked.SetIncluded(idEncoded, typeEncoded, id!, type!, GetConverter(options), value.Resource, relationshipSerializationType: value.RelationshipSerializationType);
         }
 
         private JsonObjectConverter GetConverter(JsonSerializerOptions options)

--- a/src/Jsonyte/Serialization/Attributes/SerializeAsAttribute.cs
+++ b/src/Jsonyte/Serialization/Attributes/SerializeAsAttribute.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jsonyte.Serialization.Attributes
+{
+
+    /// <summary>
+    /// Specifies how a relationship should be serialized.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class SerializeAsAttribute : Attribute
+    {
+        /// <summary>
+        /// Indicates the type of serialization for the relationship.
+        /// </summary>
+        public RelationshipSerializationType Type { get; }
+
+        /// <summary>
+        /// Constructor to initialize the serialization type.
+        /// </summary>
+        /// <param name="type"></param>
+        public SerializeAsAttribute(RelationshipSerializationType type = RelationshipSerializationType.Included)
+        {
+            Type = type;
+        }
+    }
+}

--- a/src/Jsonyte/Serialization/Contracts/PotentialRelationshipCollection.cs
+++ b/src/Jsonyte/Serialization/Contracts/PotentialRelationshipCollection.cs
@@ -10,11 +10,14 @@ namespace Jsonyte.Serialization.Contracts
 
         public readonly bool WriteImmediately;
 
-        public PotentialRelationshipCollection(JsonEncodedText relationship, object? value, bool writeImmediately)
+        public readonly RelationshipSerializationType RelationshipSerializationType;
+
+        public PotentialRelationshipCollection(JsonEncodedText relationship, object? value, bool writeImmediately, RelationshipSerializationType relationshipSerializationType)
         {
             Relationship = relationship;
             Value = value;
             WriteImmediately = writeImmediately;
+            RelationshipSerializationType = relationshipSerializationType;
         }
     }
 }

--- a/src/Jsonyte/Serialization/Contracts/RelationshipResource.cs
+++ b/src/Jsonyte/Serialization/Contracts/RelationshipResource.cs
@@ -4,9 +4,12 @@
     {
         public readonly T Resource;
 
-        public RelationshipResource(T resource)
+        public readonly RelationshipSerializationType RelationshipSerializationType;
+
+        public RelationshipResource(T resource, RelationshipSerializationType relationshipSerializationType = RelationshipSerializationType.Included)
         {
             Resource = resource;
+            RelationshipSerializationType = relationshipSerializationType;
         }
     }
 }

--- a/src/Jsonyte/Serialization/IncludedRef.cs
+++ b/src/Jsonyte/Serialization/IncludedRef.cs
@@ -22,6 +22,8 @@ namespace Jsonyte.Serialization
 
         public readonly int? RelationshipId;
 
+        private readonly RelationshipSerializationType RelationshipSerializationType;
+
         public IncludedRef(
             ulong idKey,
             ulong typeKey,
@@ -31,6 +33,7 @@ namespace Jsonyte.Serialization
             string typeString,
             JsonObjectConverter converter,
             object value,
+            RelationshipSerializationType relationshipSerializationType,
             int? relationshipId = null)
         {
             IdKey = idKey;
@@ -41,6 +44,7 @@ namespace Jsonyte.Serialization
             TypeString = typeString;
             Converter = converter;
             Value = value;
+            RelationshipSerializationType = relationshipSerializationType;
             RelationshipId = relationshipId;
         }
 
@@ -49,6 +53,11 @@ namespace Jsonyte.Serialization
         public bool IsUnwritten()
         {
             return RelationshipId != null;
+        }
+
+        public bool ShouldSerialize()
+        {
+            return RelationshipSerializationType == RelationshipSerializationType.Included;
         }
     }
 }

--- a/src/Jsonyte/Serialization/Metadata/EmptyJsonMemberInfo.cs
+++ b/src/Jsonyte/Serialization/Metadata/EmptyJsonMemberInfo.cs
@@ -106,7 +106,7 @@ namespace Jsonyte.Serialization.Metadata
         {
         }
 
-        public override void WriteRelationshipWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object resource)
+        public override void WriteRelationshipWrapped(Utf8JsonWriter writer, ref TrackedResources tracked, object resource, RelationshipSerializationType relationshipSerializationType)
         {
         }
 

--- a/src/Jsonyte/Serialization/RelationshipSerializationType.cs
+++ b/src/Jsonyte/Serialization/RelationshipSerializationType.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jsonyte.Serialization
+{
+    /// <summary>
+    /// Defines the serialization type for relationships in JSON:API.
+    /// </summary>
+    public enum RelationshipSerializationType : byte
+    {
+        /// <summary>
+        /// The relationship is serialized as a resource object with both 'id' and 'type' properties.
+        /// </summary>
+        IdAndType,
+
+        /// <summary>
+        /// This relationship is serialized with all properties included in the resource object.
+        /// </summary>
+        Included
+    }
+}

--- a/src/Jsonyte/Serialization/TrackedResources.cs
+++ b/src/Jsonyte/Serialization/TrackedResources.cs
@@ -91,7 +91,8 @@ namespace Jsonyte.Serialization
             string typeString,
             JsonObjectConverter converter,
             object value,
-            JsonEncodedText? unwrittenRelationship = null)
+            JsonEncodedText? unwrittenRelationship = null,
+            RelationshipSerializationType relationshipSerializationType = RelationshipSerializationType.Included)
         {
             references ??= new IncludedRef[CachedIncludes];
 
@@ -100,7 +101,7 @@ namespace Jsonyte.Serialization
                 return;
             }
 
-            SetIncluded(idKey, typeKey, identifier.Id.ToArray(), identifier.Type.ToArray(), idString, typeString, converter, value, unwrittenRelationship);
+            SetIncluded(idKey, typeKey, identifier.Id.ToArray(), identifier.Type.ToArray(), idString, typeString, converter, value, relationshipSerializationType, unwrittenRelationship);
         }
 
         public void SetIncluded(
@@ -110,7 +111,8 @@ namespace Jsonyte.Serialization
             string typeString,
             JsonObjectConverter converter,
             object value,
-            JsonEncodedText? unwrittenRelationship = null)
+            JsonEncodedText? unwrittenRelationship = null,
+            RelationshipSerializationType relationshipSerializationType = RelationshipSerializationType.Included)
         {
             references ??= new IncludedRef[CachedIncludes];
 
@@ -121,7 +123,7 @@ namespace Jsonyte.Serialization
                 return;
             }
 
-            SetIncluded(idKey, typeKey, id, type, idString, typeString, converter, value, unwrittenRelationship);
+            SetIncluded(idKey, typeKey, id, type, idString, typeString, converter, value, relationshipSerializationType, unwrittenRelationship);
         }
 
         private void SetIncluded(
@@ -133,13 +135,14 @@ namespace Jsonyte.Serialization
             string typeString,
             JsonObjectConverter converter,
             object value,
+            RelationshipSerializationType relationshipSerializationType,
             JsonEncodedText? unwrittenRelationship = null)
         {
             var relationshipId = unwrittenRelationship != null
                 ? Relationships.SetRelationship(unwrittenRelationship.Value)
                 : null;
 
-            var included = new IncludedRef(idKey, typeKey, id, type, idString, typeString, converter, value, relationshipId);
+            var included = new IncludedRef(idKey, typeKey, id, type, idString, typeString, converter, value, relationshipSerializationType, relationshipId);
 
             if (Count < CachedIncludes)
             {


### PR DESCRIPTION
**Feature Overview**
This pull request introduces the SerializeAsAttribute, which enables developers to specify how a relationship property in a model should be serialized. The attribute provides two serialization options:

1. Included
- The property is serialized as usual, adding its id and type to the relationships section of the JSON:API document.
- The additional attributes of the property are included in the included section of the document.

2. IdAndType
- Only the id and type of the property are serialized in the relationships section.
- The property is excluded from the included section entirely.

**Design Decisions**
To ensure flexibility and maintainability, the implementation allows specific converters to handle the attribute value based on their responsibilities.

For example:
- Anonymous Converters: These converters do not require processing of the SerializeAsAttribute because they would be unaware of attributes on the properties. 
- Document Converter: Direct initialization of the included section occurs here so we wouldn't need to apply the attribute to that property.
- Resource Object Converters: These converters are central to the serialization pipeline and handle most of the serialization logic. As such, they were updated to handle the SerializeAsAttribute and ensure that the correct serialization behavior is applied.

